### PR TITLE
Solving compatibility deprecation with 0.10.3  obspy renaming methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A python script to plot real time seismic data from a seedlink server in drum style or line style
 
-This version work with the latest stable ObsPy version (0.9.0).
+This version works with at least stable ObsPy version 0.9.0
 
 On some linux box, the time zone must be set to UTC and not GMT
 
@@ -18,21 +18,21 @@ On some linux box, the time zone must be set to UTC and not GMT
 
 Drum plots (with longer time range):
 
-    seedlink-plotter -s "G_FDF:00BHZ" --x_position 200 --y_position 50 --x_size 800 --y_size 600 -b 86400 --scale 20000 --seedlink_server "rtserver.ipgp.fr:18000" --x_scale 60
+    seedlink-plotter -s "G_FDF:00BHZ" --x_position 200 --y_position 50 --x_size 800 --y_size 600 -b 24h --scale 20000 --seedlink_server "rtserver.ipgp.fr:18000" --x_scale 60m
 
 ![Singlechannel](/img/Singlechannel.png)
 
 
 Line plot with single station (with shorter time range):
 
-    seedlink-plotter -s "G_MBO:00BHZ" -b 600 --seedlink_server "rtserver.ipgp.fr:18000"  --line_plot
+    seedlink-plotter -s "G_MBO:00BHZ" -b 10m --seedlink_server "rtserver.ipgp.fr:18000"  --line_plot
 
 ![Plot_line](/img/plot_line.png)
 
 Line plots with multiple stations (with shorter time range):
 
-    seedlink-plotter -s "G_FDF:00BHZ,G_SSB:00BHZ" --x_position 200 --y_position 50 --x_size 800 --y_size 600 -b 1800 --seedlink_server "rtserver.ipgp.fr:18000" --update_time 2
-    seedlink-plotter -s "G_FDF:00BHZ 00BHN 00BHE" --x_position 200 --y_position 50 --x_size 800 --y_size 600 -b 1800 --seedlink_server "rtserver.ipgp.fr:18000" --update_time 2
+    seedlink-plotter -s "G_FDF:00BHZ,G_SSB:00BHZ" --x_position 200 --y_position 50 --x_size 800 --y_size 600 -b 30m --seedlink_server "rtserver.ipgp.fr:18000" --update_time 2s
+    seedlink-plotter -s "G_FDF:00BHZ 00BHN 00BHE" --x_position 200 --y_position 50 --x_size 800 --y_size 600 -b 30m --seedlink_server "rtserver.ipgp.fr:18000" --update_time 2s
 
 ![Multichannel](/img/Multichannel.png)
 

--- a/seedlink_plotter/seedlink_plotter.py
+++ b/seedlink_plotter/seedlink_plotter.py
@@ -46,7 +46,6 @@ if OBSPY_VERSION < [0, 10]:
 
 
 # Compatibility checks
-
 # UTCDateTime
 try:
     UTCDateTime.format_seedlink

--- a/seedlink_plotter/seedlink_plotter.py
+++ b/seedlink_plotter/seedlink_plotter.py
@@ -32,7 +32,7 @@ import numpy as np
 
 
 OBSPY_VERSION = map(int, OBSPY_VERSION.split(".")[:2])
-OBSPY_VERSION = [0, 10]
+
 # check obspy version and warn if it's below 0.10.0, which means that a memory
 # leak is present in the used seedlink client (unless working on some master
 # branch version after obspy/obspy@5ce975c3710ca, which is impossible to check
@@ -45,6 +45,17 @@ if OBSPY_VERSION < [0, 10]:
     warnings.warn(msg)
 
 
+# Compatibility checks
+try:
+    UTCDateTime.format_seedlink     
+except AttributeError:
+    #create the new format_seedlink fonction using the old formatSeedLink method
+    def format_seedlink(self):
+        return self.formatSeedLink()        
+    # add the function in the class
+    setattr(UTCDateTime, 'format_seedlink',format_seedlink)
+    
+    
 class SeedlinkPlotter(Tkinter.Tk):
 
     """
@@ -439,7 +450,6 @@ def _parse_time_with_suffix_to_minutes(timestring):
 def main():
     parser = ArgumentParser(prog='seedlink_plotter',
                             description='Plot a realtime seismogram drum of a station')
-
     parser.add_argument(
         '-s', '--seedlink_streams', type=str, required=True,
         help='The seedlink stream selector string. It has the format '
@@ -564,9 +574,9 @@ def main():
     if drum_plot:
         round_start = UTCDateTime(now.year, now.month, now.day, now.hour, 0, 0)
         round_start = round_start + 3600 - args.backtrace_time
-        cl.begin_time = (round_start).formatSeedLink()
+        cl.begin_time = (round_start).format_seedlink()
     else:
-        cl.begin_time = (now - args.backtrace_time).formatSeedLink()
+        cl.begin_time = (now - args.backtrace_time).format_seedlink()
     cl.initialize()
     ids = cl.getTraceIDs()
     # start cl in a thread

--- a/seedlink_plotter/seedlink_plotter.py
+++ b/seedlink_plotter/seedlink_plotter.py
@@ -77,7 +77,7 @@ except AttributeError:
 try:
     SLPacket.getType
 except AttributeError:
-  # create the new packetHandler fonction using the old packet_handler method
+  # create the new getType fonction using the old get_type method
     def getType(self):
         return self.get_type()
     # add the function in the class
@@ -86,7 +86,7 @@ except AttributeError:
 try:
     SLPacket.getTrace
 except AttributeError:
-  # create the new packetHandler fonction using the old packet_handler method
+  # create the new getTrace fonction using the old get_trace method
     def getTrace(self):
         return self.get_trace()
     # add the function in the class

--- a/seedlink_plotter/seedlink_plotter.py
+++ b/seedlink_plotter/seedlink_plotter.py
@@ -9,8 +9,6 @@ matplotlib.rc('font', family="monospace")
 from obspy import Stream, Trace
 from obspy import __version__ as OBSPY_VERSION
 import Tkinter
-from obspy.seedlink.slpacket import SLPacket
-from obspy.seedlink.slclient import SLClient
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 from matplotlib.figure import Figure
 from matplotlib.ticker import MaxNLocator
@@ -19,7 +17,6 @@ from matplotlib.dates import date2num
 import matplotlib.pyplot as plt
 from obspy.core import UTCDateTime
 from obspy.core.event import Catalog
-from obspy.fdsn import Client
 from argparse import ArgumentParser
 from math import sin
 import threading
@@ -37,12 +34,21 @@ OBSPY_VERSION = map(int, OBSPY_VERSION.split(".")[:2])
 # leak is present in the used seedlink client (unless working on some master
 # branch version after obspy/obspy@5ce975c3710ca, which is impossible to check
 # reliably). see #7 and obspy/obspy#918.
+# make imports depending of the obspy version
 if OBSPY_VERSION < [0, 10]:
     msg = ("ObsPy version < 0.10.0 has a memory leak in SeedLink Client. "
            "Please update your ObsPy installation to avoid being affected "
            "by the memory leak (see "
            "https://github.com/bonaime/seedlink_plotter/issues/7).")
     warnings.warn(msg)
+    
+    from obspy.seedlink.slpacket import SLPacket
+    from obspy.seedlink.slclient import SLClient
+    from obspy.fdsn import Client
+else:
+    from obspy.clients.seedlink.slpacket import SLPacket
+    from obspy.clients.seedlink import SLClient
+    from obspy.clients.fdsn import Client
 
 
 # Compatibility checks

--- a/seedlink_plotter/seedlink_plotter.py
+++ b/seedlink_plotter/seedlink_plotter.py
@@ -114,7 +114,6 @@ class SeedlinkPlotter(Tkinter.Tk):
         canvas.show()
         canvas.get_tk_widget().pack(fill=Tkinter.BOTH, expand=1)
 
-        self.interval = args.x_scale
         self.backtrace = args.backtrace_time
         self.canvas = canvas
         self.scale = args.scale
@@ -193,8 +192,9 @@ class SeedlinkPlotter(Tkinter.Tk):
             title += ' - autoscale -'
         title += " without filtering"
         self.figure.clear()
+        print self.args.x_scale
         stream.plot(
-            fig=self.figure, type='dayplot', interval=self.args.x_scale,
+            fig=self.figure, type='dayplot', interval=int(self.args.x_scale),
             number_of_ticks=self.args.time_tick_nb, tick_format=self.args.tick_format,
             size=(self.args.x_size, self.args.y_size),
             x_labels_size=8, y_labels_size=8,
@@ -459,10 +459,9 @@ def _parse_time_with_suffix_to_seconds(timestring):
     try:
         return float(timestring)
     except:
-        pass
-    timestring, suffix = timestring[:-1], timestring[-1].lower()
-    mult = {'s': 1.0, 'm': 60.0, 'h': 3600.0, 'd': 3600.0 * 24}[suffix]
-    return float(timestring) * mult
+        timestring, suffix = timestring[:-1], timestring[-1].lower()
+        mult = {'s': 1.0, 'm': 60.0, 'h': 3600.0, 'd': 3600.0 * 24}[suffix]
+        return float(timestring) * mult
 
 
 def _parse_time_with_suffix_to_minutes(timestring):
@@ -487,7 +486,10 @@ def _parse_time_with_suffix_to_minutes(timestring):
         days.
     :rtype: float
     """
-    seconds = _parse_time_with_suffix_to_seconds(timestring)
+    try:
+        return float(timestring)
+    except:
+        seconds = _parse_time_with_suffix_to_seconds(timestring)
     return seconds / 60.0
 
 

--- a/seedlink_plotter/seedlink_plotter.py
+++ b/seedlink_plotter/seedlink_plotter.py
@@ -34,7 +34,7 @@ OBSPY_VERSION = map(int, OBSPY_VERSION.split(".")[:2])
 # leak is present in the used seedlink client (unless working on some master
 # branch version after obspy/obspy@5ce975c3710ca, which is impossible to check
 # reliably). see #7 and obspy/obspy#918.
-# make imports depending of the obspy version
+# imports depend of the obspy version
 if OBSPY_VERSION < [0, 10]:
     msg = ("ObsPy version < 0.10.0 has a memory leak in SeedLink Client. "
            "Please update your ObsPy installation to avoid being affected "

--- a/seedlink_plotter/seedlink_plotter.py
+++ b/seedlink_plotter/seedlink_plotter.py
@@ -46,16 +46,48 @@ if OBSPY_VERSION < [0, 10]:
 
 
 # Compatibility checks
+
+# UTCDateTime
 try:
-    UTCDateTime.format_seedlink     
+    UTCDateTime.format_seedlink
 except AttributeError:
-    #create the new format_seedlink fonction using the old formatSeedLink method
+    # create the new format_seedlink fonction using the old formatSeedLink
+    # method
     def format_seedlink(self):
-        return self.formatSeedLink()        
+        return self.formatSeedLink()
     # add the function in the class
-    setattr(UTCDateTime, 'format_seedlink',format_seedlink)
-    
-    
+    setattr(UTCDateTime, 'format_seedlink', format_seedlink)
+
+# SLClient
+try:
+    SLClient.packetHandler
+except AttributeError:
+  # create the new packetHandler fonction using the old packet_handler method
+    def packetHandler(self):
+        return self.packet_handler()
+    # add the function in the class
+    setattr(SLClient, 'packetHandler', packetHandler)
+
+# SLPacket
+try:
+    SLPacket.getType
+except AttributeError:
+  # create the new packetHandler fonction using the old packet_handler method
+    def getType(self):
+        return self.get_type()
+    # add the function in the class
+    setattr(SLPacket, 'getType', getType)
+
+try:
+    SLPacket.getTrace
+except AttributeError:
+  # create the new packetHandler fonction using the old packet_handler method
+    def getTrace(self):
+        return self.get_trace()
+    # add the function in the class
+    setattr(SLPacket, 'getTrace', getTrace)
+
+
 class SeedlinkPlotter(Tkinter.Tk):
 
     """
@@ -273,7 +305,7 @@ class SeedlinkUpdater(SLClient):
         self.lock = lock
         self.args = myargs
 
-    def packetHandler(self, count, slpack):
+    def packet_handler(self, count, slpack):
         """
         Processes each packet received from the SeedLinkConnection.
         :type count: int
@@ -470,10 +502,10 @@ def main():
              '"m" for minutes, "h" for hours and "d" for days.',
         default=60)
     parser.add_argument('-b', '--backtrace_time',
-            help='the number of seconds to plot (3600=1h,86400=24h). The '
-                 'following suffixes can be used as well: "m" for minutes, '
-                 '"h" for hours and "d" for days.', required=True,
-                 type=_parse_time_with_suffix_to_seconds)
+                        help='the number of seconds to plot (3600=1h,86400=24h). The '
+                        'following suffixes can be used as well: "m" for minutes, '
+                        '"h" for hours and "d" for days.', required=True,
+                        type=_parse_time_with_suffix_to_seconds)
     parser.add_argument('--x_position', type=int,
                         help='the x position of the graph', required=False, default=0)
     parser.add_argument('--y_position', type=int,
@@ -502,12 +534,12 @@ def main():
     parser.add_argument(
         '--nb_rainbow_colors', help='the numbers of colors for rainbow mode', required=False, default=10)
     parser.add_argument(
-            '--update_time',
-            help='time in seconds between each graphic update.'
-            ' The following suffixes can be used as well: "s" for seconds, '
-            '"m" for minutes, "h" for hours and "d" for days.',
-            required=False, default=10,
-            type=_parse_time_with_suffix_to_seconds)
+        '--update_time',
+        help='time in seconds between each graphic update.'
+        ' The following suffixes can be used as well: "s" for seconds, '
+        '"m" for minutes, "h" for hours and "d" for days.',
+        required=False, default=10,
+        type=_parse_time_with_suffix_to_seconds)
     parser.add_argument('--events', required=False, default=None, type=float,
                         help='plot events using obspy.neries, specify minimum magnitude')
     parser.add_argument(

--- a/seedlink_plotter/seedlink_plotter.py
+++ b/seedlink_plotter/seedlink_plotter.py
@@ -1,13 +1,9 @@
 #!/usr/bin/env python
-
 import matplotlib
 # Set the backend for matplotlib.
 matplotlib.use("TkAgg")
 matplotlib.rc('figure.subplot', hspace=0)
 matplotlib.rc('font', family="monospace")
-
-from obspy import Stream, Trace
-from obspy import __version__ as OBSPY_VERSION
 import Tkinter
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 from matplotlib.figure import Figure
@@ -15,6 +11,8 @@ from matplotlib.ticker import MaxNLocator
 from matplotlib.patheffects import withStroke
 from matplotlib.dates import date2num
 import matplotlib.pyplot as plt
+from obspy import Stream, Trace
+from obspy import __version__ as OBSPY_VERSION
 from obspy.core import UTCDateTime
 from obspy.core.event import Catalog
 from argparse import ArgumentParser
@@ -36,20 +34,23 @@ OBSPY_VERSION = map(int, OBSPY_VERSION.split(".")[:2])
 # reliably). see #7 and obspy/obspy#918.
 # imports depend of the obspy version
 if OBSPY_VERSION < [0, 10]:
-    msg = ("ObsPy version < 0.10.0 has a memory leak in SeedLink Client. "
-           "Please update your ObsPy installation to avoid being affected "
-           "by the memory leak (see "
-           "https://github.com/bonaime/seedlink_plotter/issues/7).")
-    warnings.warn(msg)
-    
-    from obspy.seedlink.slpacket import SLPacket
-    from obspy.seedlink.slclient import SLClient
-    from obspy.fdsn import Client
-else:
-    from obspy.clients.seedlink.slpacket import SLPacket
-    from obspy.clients.seedlink import SLClient
-    from obspy.clients.fdsn import Client
-
+    warning_msg = ("ObsPy version < 0.10.0 has a memory leak in SeedLink Client. "
+                   "Please update your ObsPy installation to avoid being affected "
+                   "by the memory leak (see "
+                   "https://github.com/bonaime/seedlink_plotter/issues/7).")
+    warnings.warn(warning_msg)
+elif OBSPY_VERSION == [0, 10]:
+    # Check if OBSPY_VERSION < 0.10.2
+    from obspy import __version__ as OBSPY_VERSION
+    if int(OBSPY_VERSION[5:6]) <= 2:
+        # 0.10.0 0.10.1 0.10.2
+        from obspy.seedlink.slpacket import SLPacket
+        from obspy.seedlink.slclient import SLClient
+        from obspy.fdsn import Client
+    else:
+        from obspy.clients.seedlink.slpacket import SLPacket
+        from obspy.clients.seedlink import SLClient
+        from obspy.clients.fdsn import Client
 
 # Compatibility checks
 # UTCDateTime
@@ -62,35 +63,24 @@ except AttributeError:
         return self.formatSeedLink()
     # add the function in the class
     setattr(UTCDateTime, 'format_seedlink', format_seedlink)
-
-# SLClient
-try:
-    SLClient.packetHandler
-except AttributeError:
-  # create the new packetHandler fonction using the old packet_handler method
-    def packetHandler(self):
-        return self.packet_handler()
-    # add the function in the class
-    setattr(SLClient, 'packetHandler', packetHandler)
-
 # SLPacket
 try:
-    SLPacket.getType
+    SLPacket.get_type
 except AttributeError:
-  # create the new getType fonction using the old get_type method
-    def getType(self):
-        return self.get_type()
+  # create the new get_type fonction using the old getType method
+    def get_type(self):
+        return self.getType()
     # add the function in the class
-    setattr(SLPacket, 'getType', getType)
+    setattr(SLPacket, 'get_type', get_type)
 
 try:
-    SLPacket.getTrace
+    SLPacket.get_trace
 except AttributeError:
-  # create the new getTrace fonction using the old get_trace method
-    def getTrace(self):
-        return self.get_trace()
+  # create the new get_trace fonction using the old getTrace method
+    def get_trace(self):
+        return self.getTrace()
     # add the function in the class
-    setattr(SLPacket, 'getTrace', getTrace)
+    setattr(SLPacket, 'get_trace', get_trace)
 
 
 class SeedlinkPlotter(Tkinter.Tk):
@@ -99,7 +89,8 @@ class SeedlinkPlotter(Tkinter.Tk):
     This module plots realtime seismic data from a Seedlink server
     """
 
-    def __init__(self, stream=None, events=None, myargs=None, lock=None, drum_plot=True, trace_ids=None, *args, **kwargs):
+    def __init__(self, stream=None, events=None, myargs=None, lock=None,
+                 drum_plot=True, trace_ids=None, *args, **kwargs):
         Tkinter.Tk.__init__(self, *args, **kwargs)
         self.focus_set()
         self._bind_keys()
@@ -233,7 +224,9 @@ class SeedlinkPlotter(Tkinter.Tk):
         for tr in stream:
             tr.stats.processing = []
         stream.plot(fig=fig, method="fast", draw=False, equal_scale=False,
-                    size=(self.args.x_size, self.args.y_size), title="", color='Blue', tick_format=self.args.tick_format, number_of_ticks=self.args.time_tick_nb)
+                    size=(self.args.x_size, self.args.y_size), title="",
+                    color='Blue', tick_format=self.args.tick_format,
+                    number_of_ticks=self.args.time_tick_nb)
         fig.subplots_adjust(left=0, right=1, top=1, bottom=0)
         bbox = dict(boxstyle="round", fc="w", alpha=0.8)
         path_effects = [withStroke(linewidth=4, foreground="w")]
@@ -281,12 +274,17 @@ class SeedlinkPlotter(Tkinter.Tk):
                  ha="right", va="top", bbox=bbox, fontsize="medium")
         fig.canvas.draw()
 
-    # converter for the colors gradient
     def rgb_to_hex(self, red_value, green_value, blue_value):
+        """
+            converter for the colors gradient
+        """
         return '#%02X%02X%02X' % (red_value, green_value, blue_value)
 
-        # Rainbow color generator
+        
     def rainbow_color_generator(self, max_color):
+        """
+            Rainbow color generator
+        """
         color_list = []
         frequency = 0.3
         for compteur_lignes in xrange(max_color):
@@ -310,7 +308,14 @@ class SeedlinkUpdater(SLClient):
         self.lock = lock
         self.args = myargs
 
+   
     def packet_handler(self, count, slpack):
+        """
+        for compatibility with obspy 0.10.3 renaming
+        """
+        self.packetHandler(count, slpack)
+
+    def packetHandler(self, count, slpack):
         """
         Processes each packet received from the SeedLinkConnection.
         :type count: int
@@ -327,12 +332,12 @@ class SeedlinkUpdater(SLClient):
             return False
 
         # get basic packet info
-        type = slpack.getType()
+        type = slpack.get_type()
 
         # process INFO packets here
-        if (type == SLPacket.TYPE_SLINF):
+        if type == SLPacket.TYPE_SLINF:
             return False
-        if (type == SLPacket.TYPE_SLINFT):
+        if type == SLPacket.TYPE_SLINFT:
             logging.info("Complete INFO:" + self.slconn.getInfoString())
             if self.infolevel is not None:
                 return True
@@ -340,7 +345,7 @@ class SeedlinkUpdater(SLClient):
                 return False
 
         # process packet data
-        trace = slpack.getTrace()
+        trace = slpack.get_trace()
         if trace is None:
             logging.info(
                 self.__class__.__name__ + ": blockette contains no trace")
@@ -373,7 +378,9 @@ class SeedlinkUpdater(SLClient):
 
 
 class EventUpdater():
-
+    """
+    Fetch list of seismic events
+    """
     def __init__(self, stream, events, myargs=None, lock=None):
         self.stream = stream
         self.events = events
@@ -396,11 +403,11 @@ class EventUpdater():
                 continue
             try:
                 events = self.get_events()
-            except URLError, e:
-                msg = "%s: %s\n" % (e.__class__.__name__, e)
+            except URLError, error:
+                msg = "%s: %s\n" % (error.__class__.__name__, error)
                 sys.stderr.write(msg)
-            except Exception, e:
-                msg = "%s: %s\n" % (e.__class__.__name__, e)
+            except Exception, error:
+                msg = "%s: %s\n" % (error.__class__.__name__, error)
                 sys.stderr.write(msg)
             else:
                 self.update_events(events)
@@ -413,9 +420,9 @@ class EventUpdater():
         with self.lock:
             start = min([tr.stats.starttime for tr in self.stream])
             end = max([tr.stats.endtime for tr in self.stream])
-        c = Client("NERIES")
-        events = c.get_events(starttime=start, endtime=end,
-                              minmagnitude=self.args.events)
+        neries_client = Client("NERIES")
+        events = neries_client.get_events(starttime=start, endtime=end,
+                                          minmagnitude=self.args.events)
         return events
 
     def update_events(self, events):
@@ -499,7 +506,8 @@ def main():
 
     # Real-time parameters
     parser.add_argument('--seedlink_server', type=str,
-                        help='the seedlink server to connect to with port. ex: rtserver.ipgp.fr:18000 ', required=True)
+                        help='the seedlink server to connect to with port. "\
+                        "ex: rtserver.ipgp.fr:18000 ', required=True)
     parser.add_argument(
         '--x_scale', type=_parse_time_with_suffix_to_minutes,
         help='the number of minute to plot per line'
@@ -583,59 +591,56 @@ def main():
             sys.exit()
 
     now = UTCDateTime()
-
-    if any([x in args.seedlink_streams for x in ", ?*"]) or args.line_plot:
-        drum_plot = False
-    else:
-        drum_plot = True
-
-    if drum_plot:
-        if args.time_tick_nb is None:
-            args.time_tick_nb = 13
-        if args.tick_format is None:
-            args.tick_format = '%d/%m/%y %Hh'
-    else:
-        if args.time_tick_nb is None:
-            args.time_tick_nb = 5
-        if args.tick_format is None:
-            args.tick_format = '%H:%M:%S'
-
     stream = Stream()
     events = Catalog()
     lock = threading.Lock()
 
     # cl is the seedlink client
-    cl = SeedlinkUpdater(stream, myargs=args, lock=lock)
-    cl.slconn.setSLAddress(args.seedlink_server)
-    cl.multiselect = args.seedlink_streams
-    if drum_plot:
+    seedlink_client = SeedlinkUpdater(stream, myargs=args, lock=lock)
+    seedlink_client.slconn.setSLAddress(args.seedlink_server)
+    seedlink_client.multiselect = args.seedlink_streams
+
+    # tes if drum plot or line plot
+    if any([x in args.seedlink_streams for x in ", ?*"]) or args.line_plot:
+        drum_plot = False
+        if args.time_tick_nb is None:
+            args.time_tick_nb = 5
+        if args.tick_format is None:
+            args.tick_format = '%H:%M:%S'
         round_start = UTCDateTime(now.year, now.month, now.day, now.hour, 0, 0)
         round_start = round_start + 3600 - args.backtrace_time
-        cl.begin_time = (round_start).format_seedlink()
+        seedlink_client.begin_time = (round_start).format_seedlink()
+
     else:
-        cl.begin_time = (now - args.backtrace_time).format_seedlink()
-    cl.initialize()
-    ids = cl.getTraceIDs()
+        drum_plot = True
+        if args.time_tick_nb is None:
+            args.time_tick_nb = 13
+        if args.tick_format is None:
+            args.tick_format = '%d/%m/%y %Hh'
+    seedlink_client.begin_time = (now - args.backtrace_time).format_seedlink()
+
+    seedlink_client.initialize()
+    ids = seedlink_client.getTraceIDs()
     # start cl in a thread
-    thread = threading.Thread(target=cl.run)
+    thread = threading.Thread(target=seedlink_client.run)
     thread.setDaemon(True)
     thread.start()
 
     # start another thread for event updating if requested
     if args.events is not None:
-        eu = EventUpdater(stream=stream, events=events, myargs=args, lock=lock)
-        thread = threading.Thread(target=eu.run)
+        event_updater = EventUpdater(
+            stream=stream, events=events, myargs=args, lock=lock)
+        thread = threading.Thread(target=event_updater.run)
         thread.setDaemon(True)
         thread.start()
 
-    # Wait few seconds to get data
+    # Wait few seconds to get data for the first plot
     time.sleep(2)
 
     master = SeedlinkPlotter(stream=stream, events=events, myargs=args,
                              lock=lock, drum_plot=drum_plot,
                              trace_ids=ids)
     master.mainloop()
-
 
 if __name__ == '__main__':
     main()

--- a/seedlink_plotter/seedlink_plotter.py
+++ b/seedlink_plotter/seedlink_plotter.py
@@ -40,8 +40,8 @@ if OBSPY_VERSION < [0, 10]:
     warnings.warn(warning_msg)
 elif OBSPY_VERSION == [0, 10]:
     # Check if OBSPY_VERSION < 0.10.2
-    from obspy import __version__ as OBSPY_VERSION
-    if int(OBSPY_VERSION[5:6]) <= 2:
+    from obspy import __version__ as OBSPY_VERSION_small
+    if int(OBSPY_VERSION_small[5:6]) <= 2:
         # 0.10.0 0.10.1 0.10.2
         from obspy.seedlink.slpacket import SLPacket
         from obspy.seedlink.slclient import SLClient

--- a/seedlink_plotter/seedlink_plotter.py
+++ b/seedlink_plotter/seedlink_plotter.py
@@ -192,9 +192,8 @@ class SeedlinkPlotter(Tkinter.Tk):
             title += ' - autoscale -'
         title += " without filtering"
         self.figure.clear()
-        print self.args.x_scale
         stream.plot(
-            fig=self.figure, type='dayplot', interval=int(self.args.x_scale),
+            fig=self.figure, type='dayplot', interval=self.args.x_scale,
             number_of_ticks=self.args.time_tick_nb, tick_format=self.args.tick_format,
             size=(self.args.x_size, self.args.y_size),
             x_labels_size=8, y_labels_size=8,


### PR DESCRIPTION
add format_seedlink to UTCDateTime if needed
remove OBSPY_VERSION = [0, 10]